### PR TITLE
Unit test (unhappy and happy path) for str.format() with specifiers '<, >, ^'

### DIFF
--- a/test-data/unit/check-formatting.test
+++ b/test-data/unit/check-formatting.test
@@ -265,6 +265,16 @@ b'%c' % (123)
 -- ------------------
 
 
+[case testFormatCallNoneAlignment]
+'{:<1}'.format(None)  # E: Alignment format specifier "<" is not supported for None
+'{:>1}'.format(None)  # E: Alignment format specifier ">" is not supported for None
+'{:^1}'.format(None)  # E: Alignment format specifier "^" is not supported for None
+
+'{:<10}'.format('16') # OK
+'{:>10}'.format('16') # OK
+'{:^10}'.format('16') # OK
+[builtins fixtures/primitives.pyi]
+
 [case testFormatCallParseErrors]
 '}'.format()  # E: Invalid conversion specifier in format string: unexpected }
 '{'.format()  # E: Invalid conversion specifier in format string: unmatched {


### PR DESCRIPTION
This PR added a total of 6 test cases for `str.format()` with specifiers `<, >, ^`.

- The first three tests check that when None argument is passed into `str.format()` with any of the specifiers `<, >, ^` will give the expected Error message.
- The last three tests check that when a valid string is passed in then there is no error message is produced.

Ran locally with command `pytest -n0 -k testFormatCallNoneAlignment` and the test passed
<img width="1121" alt="image" src="https://github.com/user-attachments/assets/c9ab5ba0-2320-4f9a-8105-d436e7bdc516" />

