### PR TITLE
Catch user-defined function that does not have `__format__` but called on str.format()

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -339,7 +339,6 @@ class StringFormatterChecker:
 
         The core logic for format checking is implemented in this method.
         """
-        #print("in format call")
         assert all(s.key for s in specs), "Keys must be auto-generated first!"
         replacements = self.find_replacements_in_call(call, [cast(str, s.key) for s in specs])
         assert len(replacements) == len(specs)

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -487,14 +487,6 @@ class StringFormatterChecker:
             for s in substring:
                 if (s in fullname):
                     return True
-        # if isinstance(actual_type, NoneType) or isinstance(actual_type, LiteralType):
-        #     return True
-        # if isinstance(actual_type, Instance):
-        #     fullname = actual_type.type.fullname
-        #     substring = ["builtins.", "mypyc.", "mypy.", "uuid.", "uuid.", "pathlib."]
-        #     for s in substring:
-        #         if (s in fullname):
-        #             return True
         return False
         
 


### PR DESCRIPTION
This PR attempted to fix a bug where a user-defined function does not have `__format__` but called `str.format()`, then myPy should catch this, but currently myPy does not detect this.

**For example:**
In this example, since `GoodFomat()` has `__format__`, the call to `"{:*^15}".format(GoodFormat())` should succeed.
`class GoodFormat:`
`    def __format__(self, format_spec):`
`        return f"<Formatted:{format_spec}>"`

However in this example, `Foo()` does not have `__format__` so it should produce an error message because `str.format()` would not know how to format when we make the call `"{:*^15}".format(Foo())`. Currently, myPy passes this case.
`class Foo:`
`    def __str__(self): return "hello"`

**Result:**
After the fix, this is what I got 
<img width="832" alt="image" src="https://github.com/user-attachments/assets/27c107fe-21b8-445e-b569-504f9dcb268f" />

**Run Test:**
- Ran the local test as the screenshot above
- Ran the command `python runtests.py self`
