### PR TITLE
Attempt to fix distribute Tuple issue 

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -285,7 +285,7 @@ def is_same_type(
 
 
 # This is a helper function used to check for recursive type of distributed tuple
-def structurally_recursive(typ: Type, seen: set[Type] | None = None) -> bool:
+def is_structurally_recursive(typ: Type, seen: set[Type] | None = None) -> bool:
     if seen is None:
         seen = set()
     typ = get_proper_type(typ)
@@ -293,9 +293,9 @@ def structurally_recursive(typ: Type, seen: set[Type] | None = None) -> bool:
         return True
     seen.add(typ)
     if isinstance(typ, UnionType):
-        return any(structurally_recursive(item, seen.copy()) for item in typ.items)
+        return any(is_structurally_recursive(item, seen.copy()) for item in typ.items)
     if isinstance(typ, TupleType):
-        return any(structurally_recursive(item, seen.copy()) for item in typ.items)
+        return any(is_structurally_recursive(item, seen.copy()) for item in typ.items)
     return False
 
 
@@ -323,7 +323,7 @@ def _is_subtype(
     if isinstance(left, TupleType) and isinstance(right, UnionType):
         # check only if not recursive type because if recursive type,
         # test run into maximum recursive depth reached
-        if not structurally_recursive(left) and not structurally_recursive(right):
+        if not is_structurally_recursive(left) and not is_structurally_recursive(right):
             fallback = left.partial_fallback
             tuple_items = left.items
             if hasattr(left, "fallback") and left.fallback is not None:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -207,6 +207,8 @@ def is_subtype(
                     fb = left.fallback
                 distributed.append(TupleType(list(combo), fallback=fb))
             simplified = make_simplified_union(distributed)
+            if is_equivalent(simplified, right):
+                return True
             return _is_subtype(simplified, right, subtype_context, proper_subtype=False)
     return _is_subtype(left, right, subtype_context, proper_subtype=False)
 


### PR DESCRIPTION
This PR is an attempt to fix issue #18922 from the myPy repo.
Issue link: https://github.com/python/mypy/issues/18922#issuecomment-2818754738

The approach addresses the bug report by explicitly distributing union types across tuple elements when a TupleType is compared against a UnionType. It first checks whether any elements of the tuple are themselves union types, and if so, computes the Cartesian product of all combinations of those element types. For each combination, it constructs a new TupleType representing one possible instantiation of the original tuple. These are then combined into a single UnionType using make_simplified_union, effectively transforming something like Tuple[float, Optional[float]] into Union[Tuple[float, float], Tuple[float, None]]. Finally, this expanded union is compared to the right-hand side type for subtyping. 

This approaches successful identify there is no issue with:
```
from typing import Union, Tuple, Optional

def id(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[float, None]]:
    return x
```
and identify there is an issue with:
```
from typing import Union, Tuple, Optional

def id(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, str], Tuple[float, None]]:
    return x
```

However, this approach leads to an maximum recursive depth error when running on recursive data structure, more specifically on the test testRecursiveDoubleUnionNoCrash in check-recursive-types.test.