### PR TITLE
Extend check on None for str.format() 

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -487,14 +487,6 @@ class StringFormatterChecker:
             for s in substring:
                 if (s in fullname):
                     return True
-        # if isinstance(actual_type, NoneType) or isinstance(actual_type, LiteralType):
-        #     return True
-        # if isinstance(actual_type, Instance):
-        #     fullname = actual_type.type.fullname
-        #     substring = ["builtins.", "mypyc.", "mypy.", "uuid.", "uuid.", "pathlib."]
-        #     for s in substring:
-        #         if (s in fullname):
-        #             return True
         return False
         
 

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -44,6 +44,7 @@ from mypy.nodes import (
     StrExpr,
     TempNode,
     TupleExpr,
+    Var,
 )
 from mypy.parse import parse
 from mypy.subtypes import is_subtype
@@ -452,24 +453,27 @@ class StringFormatterChecker:
                     code=codes.STRING_FORMATTING,
                 )
 
-        a_type = get_proper_type(actual_type)
-        if isinstance(a_type, NoneType):
+        if isinstance(get_proper_type(actual_type), NoneType):
             # Perform type check of alignment specifiers on None
-            if spec.format_spec and any(c in spec.format_spec for c in "<>^"):
-                specifierIndex = -1
-                for i in range(len("<>^")):
-                    if spec.format_spec[i] in "<>^":
-                        specifierIndex = i
-                if specifierIndex > -1:
-                    self.msg.fail(
-                        (
-                            f"Alignment format specifier "
-                            f'"{spec.format_spec[specifierIndex]}" '
-                            f"is not supported for None"
-                        ),
-                        call,
-                        code=codes.STRING_FORMATTING,
-                    )
+            # If spec.format_spec is None then we use "" instead of avoid crashing
+            specifier_char = None
+            if spec.non_standard_format_spec == True and isinstance(call.args[-1], StrExpr):
+                arg = call.args[-1].value
+                specifier_char = next((c for c in (arg or "") if c in "<>^"), None)
+            elif isinstance(spec.format_spec, str):
+                specifier_char = next((c for c in (spec.format_spec or "") if c in "<>^"), None)
+            
+            if specifier_char:
+                self.msg.fail(
+                    (
+                        f"Alignment format specifier "
+                        f'"{specifier_char}" '
+                        f"is not supported for None"
+                    ),
+                    call,
+                    code=codes.STRING_FORMATTING,
+                )
+            
 
     def find_replacements_in_call(self, call: CallExpr, keys: list[str]) -> list[Expression]:
         """Find replacement expression for every specifier in str.format() call.

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -50,13 +50,14 @@ from mypy.subtypes import is_subtype
 from mypy.typeops import custom_special_method
 from mypy.types import (
     AnyType,
+    DeletedType,
     Instance,
     LiteralType,
     NoneType,
     TupleType,
     Type,
-    TypeType,
     TypeOfAny,
+    TypeType,
     TypeVarTupleType,
     TypeVarType,
     UnionType,
@@ -64,7 +65,6 @@ from mypy.types import (
     find_unpack_in_list,
     get_proper_type,
     get_proper_types,
-    DeletedType
 )
 
 FormatStringExpr: _TypeAlias = Union[StrExpr, BytesExpr]
@@ -339,7 +339,7 @@ class StringFormatterChecker:
 
         The core logic for format checking is implemented in this method.
         """
-        #print("in format call")
+        # print("in format call")
         assert all(s.key for s in specs), "Keys must be auto-generated first!"
         replacements = self.find_replacements_in_call(call, [cast(str, s.key) for s in specs])
         assert len(replacements) == len(specs)
@@ -451,7 +451,7 @@ class StringFormatterChecker:
                     call,
                     code=codes.STRING_FORMATTING,
                 )
-        actual_type = get_proper_type(actual_type) 
+        actual_type = get_proper_type(actual_type)
         if isinstance(actual_type, NoneType):
             # Perform type check of alignment specifiers on None
             if spec.format_spec and any(c in spec.format_spec for c in "<>^"):
@@ -461,34 +461,48 @@ class StringFormatterChecker:
                         specifierIndex = i
                 if specifierIndex > -1:
                     self.msg.fail(
-						(
-							f'Alignment format specifier '
-							f'"{spec.format_spec[specifierIndex]}" '
-							f'is not supported for None'
-						),
-						call,
-						code=codes.STRING_FORMATTING,
-					)        
+                        (
+                            f"Alignment format specifier "
+                            f'"{spec.format_spec[specifierIndex]}" '
+                            f"is not supported for None"
+                        ),
+                        call,
+                        code=codes.STRING_FORMATTING,
+                    )
         if spec.format_spec and not self.type_supports_formatting(actual_type):
             self.msg.fail(
                 f'"{actual_type}" does not support custom formatting (no __format__ method)',
                 call,
                 code=codes.STRING_FORMATTING,
             )
-    
+
     def type_supports_formatting(self, actual_type: Type) -> bool:
-        actual_type = get_proper_type(actual_type) 
-        if isinstance(actual_type, (NoneType, LiteralType, AnyType, TupleType, TypeType, DeletedType)):
-            return True;
+        actual_type = get_proper_type(actual_type)
+        if isinstance(
+            actual_type, (NoneType, LiteralType, AnyType, TupleType, TypeType, DeletedType)
+        ):
+            return True
         if isinstance(actual_type, Instance):
             fullname = actual_type.type.fullname
-            substring = ["builtins.", "mypy.", "mypyc.", "typing.", "types.", "uuid.", "pathlib.",
-            "_pytest.", "inspect.", "os.", "sys.", "re.", "collections."]
+            substring = [
+                "builtins.",
+                "mypy.",
+                "mypyc.",
+                "typing.",
+                "types.",
+                "uuid.",
+                "pathlib.",
+                "_pytest.",
+                "inspect.",
+                "os.",
+                "sys.",
+                "re.",
+                "collections.",
+            ]
             for s in substring:
-                if (s in fullname):
+                if s in fullname:
                     return True
         return False
-        
 
     def find_replacements_in_call(self, call: CallExpr, keys: list[str]) -> list[Expression]:
         """Find replacement expression for every specifier in str.format() call.

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -44,21 +44,18 @@ from mypy.nodes import (
     StrExpr,
     TempNode,
     TupleExpr,
-    Var,
 )
 from mypy.parse import parse
 from mypy.subtypes import is_subtype
 from mypy.typeops import custom_special_method
 from mypy.types import (
     AnyType,
-    DeletedType,
     Instance,
     LiteralType,
     NoneType,
     TupleType,
     Type,
     TypeOfAny,
-    TypeType,
     TypeVarTupleType,
     TypeVarType,
     UnionType,
@@ -457,12 +454,12 @@ class StringFormatterChecker:
             # Perform type check of alignment specifiers on None
             # If spec.format_spec is None then we use "" instead of avoid crashing
             specifier_char = None
-            if spec.non_standard_format_spec == True and isinstance(call.args[-1], StrExpr):
+            if spec.non_standard_format_spec and isinstance(call.args[-1], StrExpr):
                 arg = call.args[-1].value
                 specifier_char = next((c for c in (arg or "") if c in "<>^"), None)
             elif isinstance(spec.format_spec, str):
                 specifier_char = next((c for c in (spec.format_spec or "") if c in "<>^"), None)
-            
+
             if specifier_char:
                 self.msg.fail(
                     (
@@ -473,7 +470,6 @@ class StringFormatterChecker:
                     call,
                     code=codes.STRING_FORMATTING,
                 )
-            
 
     def find_replacements_in_call(self, call: CallExpr, keys: list[str]) -> list[Expression]:
         """Find replacement expression for every specifier in str.format() call.

--- a/test-data/unit/check-formatting.test
+++ b/test-data/unit/check-formatting.test
@@ -266,6 +266,8 @@ b'%c' % (123)
 
 
 [case testFormatCallNoneAlignment]
+from typing import Optional
+
 '{:<1}'.format(None)  # E: Alignment format specifier "<" is not supported for None
 '{:>1}'.format(None)  # E: Alignment format specifier ">" is not supported for None
 '{:^1}'.format(None)  # E: Alignment format specifier "^" is not supported for None
@@ -273,6 +275,25 @@ b'%c' % (123)
 '{:<10}'.format('16') # OK
 '{:>10}'.format('16') # OK
 '{:^10}'.format('16') # OK
+
+'{!s:<5}'.format(None) # OK
+'{!s:>5}'.format(None) # OK
+'{!s:^5}'.format(None) # OK
+
+f"{None!s:<5}"  # OK
+f"{None!s:>5}"  # OK
+f"{None!s:^5}"  # OK
+
+
+f"{None:<5}"  # E: Alignment format specifier "<" is not supported for None
+f"{None:>5}"  # E: Alignment format specifier ">" is not supported for None
+f"{None:^5}"  # E: Alignment format specifier "^" is not supported for None
+
+my_var: Optional[str] = None
+"{:<2}".format(my_var) # E: Alignment format specifier "<" is not supported for None
+my_var = "test"
+"{:>2}".format(my_var) # OK
+
 [builtins fixtures/primitives.pyi]
 
 [case testFormatCallParseErrors]

--- a/test.py
+++ b/test.py
@@ -1,7 +1,0 @@
-class GoodFormat:
-    def __format__(self, format_spec):
-        return f"<Formatted:{format_spec}>"
-"{:*^15}".format(GoodFormat())
-class Foo1:
-    def __str__(self): return "hello"
-"{:*^15}".format(Foo1())

--- a/test.py
+++ b/test.py
@@ -1,0 +1,7 @@
+class GoodFormat:
+    def __format__(self, format_spec):
+        return f"<Formatted:{format_spec}>"
+"{:*^15}".format(GoodFormat())
+class Foo1:
+    def __str__(self): return "hello"
+"{:*^15}".format(Foo1())


### PR DESCRIPTION
**Original issue:**
We did not correctly check for None value when str.format() is called with `f-string`

**Solution:**
Added one more test and handle in a separate if branch for when `f-string` is involved

**Unit tests**
Added some more tests on checking the behavior of str.format called with `f-string` and union types.
