### PR TITLE
Distribute tuple test

### DIFF
--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1815,3 +1815,43 @@ class tuple_aa_subclass(Tuple[A, A]): ...
 
 inst_tuple_aa_subclass: tuple_aa_subclass = tuple_aa_subclass((A(), A()))[:]  # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "tuple_aa_subclass")
 [builtins fixtures/tuple.pyi]
+
+# ----------------------------------------------------------------------------
+# Union-in-Tuple distribution
+# ----------------------------------------------------------------------------
+
+[case testTupleUnionDistributionSuccess]
+from typing import Tuple, Optional, Union
+
+def f1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[float, None]]:
+    return x
+
+def f2(x: Tuple[Union[int, str], float]) -> Union[Tuple[int, float], Tuple[str, float]]:
+    return x
+
+def f3(x: Tuple[int, Union[str, None]]) -> Union[Tuple[int, str], Tuple[int, None]]:
+    return x
+
+def f4(x: Tuple[Union[int, float]]) -> Union[Tuple[int], Tuple[float]]:
+    return x
+
+def f5(x: Tuple[Union[int, str], Union[bool, None]]) -> Union[
+    Tuple[int, bool],
+    Tuple[int, None],
+    Tuple[str, bool],
+    Tuple[str, None],
+]:
+    return x
+
+[builtins fixtures/tuple.pyi]
+
+[case testTupleUnionDistributionFail]
+from typing import Tuple, Optional, Union
+
+def g1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[str, float]]:
+    return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, float], Tuple[str, float]]")
+
+def g2(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, str], Tuple[float, None]]:
+    return x # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, str], Tuple[float, None]]")
+
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
**What changes are these tests trying to test?**
The Issue and solution is described in this [PR](https://github.com/VallinZ/mypy/pull/4)

**Some important notes:**
Since the implemented solution leads to an maximum recursive depth error when running on recursive data structure, some higher level recursive tests were not able to be added. Therefore, the below test cases only target certain cases that the implementation takes care of. In the future, once the maximum recursive depth error is fixed, more tests should be added.
For example, the following test case should succeed but it currently fails with the error `Incompatible return value type (got "Tuple[int, Tuple[Union[str, bytes], float]]", expected "Union[Tuple[int, Tuple[str, float]], Tuple[int, Tuple[bytes, float]]]")`
 ```
def exampleTest(x: Tuple[int, Tuple[Union[str, bytes], float]]) -> Union[
    Tuple[int, Tuple[str, float]],
    Tuple[int, Tuple[bytes, float]],
]:
    return x
 ```

**Success cases (testTupleUnionDistributionSuccess)**

- f1: Distribute Optional[float] in second position

- f2: Distribute Union[int,str] in first position

- f3: Distribute Union[str,None] in second position

- f4: Single-element tuple with Union[int,float]

- f5: Two positions both containing unions

**Failure cases (testTupleUnionDistributionFail)**

- g1: Mismatched first branch (str vs. expected float)

- g2: Mismatched second branch (str vs. expected float)

Note: Each case ends with [builtins fixtures/tuple.pyi] to import the tuple stubs required by the harness.
