### PR TITLE
Attempt to fix distribute Tuple Problem

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -285,7 +285,7 @@ def is_same_type(
 
 
 # This is a helper function used to check for recursive type of distributed tuple
-def structurally_recursive(typ: Type, seen: set[Type] | None = None) -> bool:
+def is_structurally_recursive(typ: Type, seen: set[Type] | None = None) -> bool:
     if seen is None:
         seen = set()
     typ = get_proper_type(typ)
@@ -293,9 +293,9 @@ def structurally_recursive(typ: Type, seen: set[Type] | None = None) -> bool:
         return True
     seen.add(typ)
     if isinstance(typ, UnionType):
-        return any(structurally_recursive(item, seen.copy()) for item in typ.items)
+        return any(is_structurally_recursive(item, seen.copy()) for item in typ.items)
     if isinstance(typ, TupleType):
-        return any(structurally_recursive(item, seen.copy()) for item in typ.items)
+        return any(is_structurally_recursive(item, seen.copy()) for item in typ.items)
     return False
 
 
@@ -323,7 +323,7 @@ def _is_subtype(
     if isinstance(left, TupleType) and isinstance(right, UnionType):
         # check only if not recursive type because if recursive type,
         # test run into maximum recursive depth reached
-        if not structurally_recursive(left) and not structurally_recursive(right):
+        if not is_structurally_recursive(left) and not is_structurally_recursive(right):
             fallback = left.partial_fallback
             tuple_items = left.items
             if hasattr(left, "fallback") and left.fallback is not None:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -207,6 +207,8 @@ def is_subtype(
                     fb = left.fallback
                 distributed.append(TupleType(list(combo), fallback=fb))
             simplified = make_simplified_union(distributed)
+            if is_equivalent(simplified, right):
+                return True
             return _is_subtype(simplified, right, subtype_context, proper_subtype=False)
     return _is_subtype(left, right, subtype_context, proper_subtype=False)
 

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1815,3 +1815,43 @@ class tuple_aa_subclass(Tuple[A, A]): ...
 
 inst_tuple_aa_subclass: tuple_aa_subclass = tuple_aa_subclass((A(), A()))[:]  # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "tuple_aa_subclass")
 [builtins fixtures/tuple.pyi]
+
+# ----------------------------------------------------------------------------
+# Union-in-Tuple distribution
+# ----------------------------------------------------------------------------
+
+[case testTupleUnionDistributionSuccess]
+from typing import Tuple, Optional, Union
+
+def f1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[float, None]]:
+    return x
+
+def f2(x: Tuple[Union[int, str], float]) -> Union[Tuple[int, float], Tuple[str, float]]:
+    return x
+
+def f3(x: Tuple[int, Union[str, None]]) -> Union[Tuple[int, str], Tuple[int, None]]:
+    return x
+
+def f4(x: Tuple[Union[int, float]]) -> Union[Tuple[int], Tuple[float]]:
+    return x
+
+def f5(x: Tuple[Union[int, str], Union[bool, None]]) -> Union[
+    Tuple[int, bool],
+    Tuple[int, None],
+    Tuple[str, bool],
+    Tuple[str, None],
+]:
+    return x
+
+[builtins fixtures/tuple.pyi]
+
+[case testTupleUnionDistributionFail]
+from typing import Tuple, Optional, Union
+
+def g1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[str, float]]:
+    return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, float], Tuple[str, float]]")
+
+def g2(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, str], Tuple[float, None]]:
+    return x # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, str], Tuple[float, None]]")
+
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1855,4 +1855,3 @@ class tuple_aa_subclass(Tuple[A, A]): ...
 
 inst_tuple_aa_subclass: tuple_aa_subclass = tuple_aa_subclass((A(), A()))[:]  # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "tuple_aa_subclass")
 [builtins fixtures/tuple.pyi]
-

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1040,6 +1040,45 @@ reveal_type(x)  # N: Revealed type is "Tuple[builtins.int, fallback=__main__.Tes
 [builtins fixtures/tuple.pyi]
 [out]
 
+# ----------------------------------------------------------------------------
+# Union-in-Tuple distribution
+# ----------------------------------------------------------------------------
+
+[case testTupleUnionDistributionSuccess]
+from typing import Tuple, Optional, Union
+
+def f1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[float, None]]:
+    return x
+
+def f2(x: Tuple[Union[int, str], float]) -> Union[Tuple[int, float], Tuple[str, float]]:
+    return x
+
+def f3(x: Tuple[int, Union[str, None]]) -> Union[Tuple[int, str], Tuple[int, None]]:
+    return x
+
+def f4(x: Tuple[Union[int, float]]) -> Union[Tuple[int], Tuple[float]]:
+    return x
+
+def f5(x: Tuple[Union[int, str], Union[bool, None]]) -> Union[
+    Tuple[int, bool],
+    Tuple[int, None],
+    Tuple[str, bool],
+    Tuple[str, None],
+]:
+    return x
+
+[builtins fixtures/tuple.pyi]
+
+[case testTupleUnionDistributionFail]
+from typing import Tuple, Optional, Union
+
+def g1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[str, float]]:
+    return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, float], Tuple[str, float]]")
+
+def g2(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, str], Tuple[float, None]]:
+    return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, str], Tuple[float, None]]")
+
+[builtins fixtures/tuple.pyi]
 
 -- Variable-length tuples (Tuple[t, ...] with literal '...')
 -- ---------------------------------------------------------

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1855,3 +1855,4 @@ class tuple_aa_subclass(Tuple[A, A]): ...
 
 inst_tuple_aa_subclass: tuple_aa_subclass = tuple_aa_subclass((A(), A()))[:]  # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "tuple_aa_subclass")
 [builtins fixtures/tuple.pyi]
+

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1852,7 +1852,7 @@ def g1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[str
     return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, float], Tuple[str, float]]")
 
 def g2(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, str], Tuple[float, None]]:
-    return x # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, str], Tuple[float, None]]")
+    return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, str], Tuple[float, None]]")
 
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1040,9 +1040,10 @@ reveal_type(x)  # N: Revealed type is "Tuple[builtins.int, fallback=__main__.Tes
 [builtins fixtures/tuple.pyi]
 [out]
 
-# ----------------------------------------------------------------------------
-# Union-in-Tuple distribution
-# ----------------------------------------------------------------------------
+
+-- Union-in-Tuple distribution
+-- ---------------------------------------------------------
+
 
 [case testTupleUnionDistributionSuccess]
 from typing import Tuple, Optional, Union
@@ -1066,8 +1067,8 @@ def f5(x: Tuple[Union[int, str], Union[bool, None]]) -> Union[
     Tuple[str, None],
 ]:
     return x
-
 [builtins fixtures/tuple.pyi]
+[out]
 
 [case testTupleUnionDistributionFail]
 from typing import Tuple, Optional, Union
@@ -1077,8 +1078,9 @@ def g1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[str
 
 def g2(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, str], Tuple[float, None]]:
     return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, str], Tuple[float, None]]")
-
 [builtins fixtures/tuple.pyi]
+[out]
+
 
 -- Variable-length tuples (Tuple[t, ...] with literal '...')
 -- ---------------------------------------------------------
@@ -1854,3 +1856,6 @@ class tuple_aa_subclass(Tuple[A, A]): ...
 
 inst_tuple_aa_subclass: tuple_aa_subclass = tuple_aa_subclass((A(), A()))[:]  # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "tuple_aa_subclass")
 [builtins fixtures/tuple.pyi]
+
+-- 
+-- --------------------

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1855,4 +1855,3 @@ def g2(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, str], Tuple[float
     return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, str], Tuple[float, None]]")
 
 [builtins fixtures/tuple.pyi]
-

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -524,6 +524,46 @@ class A: pass
 class B: pass
 [builtins fixtures/tuple.pyi]
 
+# ----------------------------------------------------------------------------
+# Union-in-Tuple distribution
+# ----------------------------------------------------------------------------
+
+[case testTupleUnionDistributionSuccess]
+from typing import Tuple, Optional, Union
+
+def f1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[float, None]]:
+    return x
+
+def f2(x: Tuple[Union[int, str], float]) -> Union[Tuple[int, float], Tuple[str, float]]:
+    return x
+
+def f3(x: Tuple[int, Union[str, None]]) -> Union[Tuple[int, str], Tuple[int, None]]:
+    return x
+
+def f4(x: Tuple[Union[int, float]]) -> Union[Tuple[int], Tuple[float]]:
+    return x
+
+def f5(x: Tuple[Union[int, str], Union[bool, None]]) -> Union[
+    Tuple[int, bool],
+    Tuple[int, None],
+    Tuple[str, bool],
+    Tuple[str, None],
+]:
+    return x
+
+[builtins fixtures/tuple.pyi]
+
+[case testTupleUnionDistributionFail]
+from typing import Tuple, Optional, Union
+
+def g1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[str, float]]:
+    return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, float], Tuple[str, float]]")
+
+def g2(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, str], Tuple[float, None]]:
+    return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, str], Tuple[float, None]]")
+
+[builtins fixtures/tuple.pyi]
+
 [case testMultipleAssignmentWithNonTupleRvalue]
 a: A
 b: B
@@ -1814,44 +1854,4 @@ class A: ...
 class tuple_aa_subclass(Tuple[A, A]): ...
 
 inst_tuple_aa_subclass: tuple_aa_subclass = tuple_aa_subclass((A(), A()))[:]  # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "tuple_aa_subclass")
-[builtins fixtures/tuple.pyi]
-
-# ----------------------------------------------------------------------------
-# Union-in-Tuple distribution
-# ----------------------------------------------------------------------------
-
-[case testTupleUnionDistributionSuccess]
-from typing import Tuple, Optional, Union
-
-def f1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[float, None]]:
-    return x
-
-def f2(x: Tuple[Union[int, str], float]) -> Union[Tuple[int, float], Tuple[str, float]]:
-    return x
-
-def f3(x: Tuple[int, Union[str, None]]) -> Union[Tuple[int, str], Tuple[int, None]]:
-    return x
-
-def f4(x: Tuple[Union[int, float]]) -> Union[Tuple[int], Tuple[float]]:
-    return x
-
-def f5(x: Tuple[Union[int, str], Union[bool, None]]) -> Union[
-    Tuple[int, bool],
-    Tuple[int, None],
-    Tuple[str, bool],
-    Tuple[str, None],
-]:
-    return x
-
-[builtins fixtures/tuple.pyi]
-
-[case testTupleUnionDistributionFail]
-from typing import Tuple, Optional, Union
-
-def g1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[str, float]]:
-    return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, float], Tuple[str, float]]")
-
-def g2(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, str], Tuple[float, None]]:
-    return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, str], Tuple[float, None]]")
-
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1856,6 +1856,3 @@ class tuple_aa_subclass(Tuple[A, A]): ...
 
 inst_tuple_aa_subclass: tuple_aa_subclass = tuple_aa_subclass((A(), A()))[:]  # E: Incompatible types in assignment (expression has type "Tuple[A, A]", variable has type "tuple_aa_subclass")
 [builtins fixtures/tuple.pyi]
-
--- 
--- --------------------

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -524,46 +524,6 @@ class A: pass
 class B: pass
 [builtins fixtures/tuple.pyi]
 
-# ----------------------------------------------------------------------------
-# Union-in-Tuple distribution
-# ----------------------------------------------------------------------------
-
-[case testTupleUnionDistributionSuccess]
-from typing import Tuple, Optional, Union
-
-def f1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[float, None]]:
-    return x
-
-def f2(x: Tuple[Union[int, str], float]) -> Union[Tuple[int, float], Tuple[str, float]]:
-    return x
-
-def f3(x: Tuple[int, Union[str, None]]) -> Union[Tuple[int, str], Tuple[int, None]]:
-    return x
-
-def f4(x: Tuple[Union[int, float]]) -> Union[Tuple[int], Tuple[float]]:
-    return x
-
-def f5(x: Tuple[Union[int, str], Union[bool, None]]) -> Union[
-    Tuple[int, bool],
-    Tuple[int, None],
-    Tuple[str, bool],
-    Tuple[str, None],
-]:
-    return x
-
-[builtins fixtures/tuple.pyi]
-
-[case testTupleUnionDistributionFail]
-from typing import Tuple, Optional, Union
-
-def g1(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[str, float]]:
-    return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, float], Tuple[str, float]]")
-
-def g2(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, str], Tuple[float, None]]:
-    return x  # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, str], Tuple[float, None]]")
-
-[builtins fixtures/tuple.pyi]
-
 [case testMultipleAssignmentWithNonTupleRvalue]
 a: A
 b: B

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1855,3 +1855,4 @@ def g2(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, str], Tuple[float
     return x # E: Incompatible return value type (got "Tuple[float, Optional[float]]", expected "Union[Tuple[float, str], Tuple[float, None]]")
 
 [builtins fixtures/tuple.pyi]
+


### PR DESCRIPTION
### **What is being changed? ⁉️**
This PR is an attempt to fix issue #18922 from the myPy repo.
Issue link: https://github.com/python/mypy/issues/18922#issuecomment-2818754738

### **How is it implemented? 🛠️**
The approach addresses the bug report by explicitly distributing union types across tuple elements when a TupleType is compared against a UnionType. It first checks whether any elements of the tuple are themselves union types, and if so, computes the Cartesian product of all combinations of those element types. For each combination, it constructs a new TupleType representing one possible instantiation of the original tuple. These are then combined into a single UnionType using make_simplified_union, effectively transforming something like Tuple[float, Optional[float]] into Union[Tuple[float, float], Tuple[float, None]]. Finally, this expanded union is compared to the right-hand side type for subtyping. 

### **Results 📊**
This approaches successful identify there is no issue with:
```
from typing import Union, Tuple, Optional

def id(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, float], Tuple[float, None]]:
    return x
```
and identify there is an issue with:
```
from typing import Union, Tuple, Optional

def id(x: Tuple[float, Optional[float]]) -> Union[Tuple[float, str], Tuple[float, None]]:
    return x
```

### **Limitation of this approach 🔄**
However, this approach leads to an maximum recursive depth error when running on recursive data structure, more specifically on the test testRecursiveDoubleUnionNoCrash in check-recursive-types.test.  The following example is two recursive data type that are trying to get checked whether they are a subtype of another.  However, they don't fall under `is_recursive_pair` case, so they continue on to get checked, since they are recursive, the check goes on forever.  An attempt with cache was also tried but failed due to these datatypes don't have an `last_known` property.

Example: 
```
tuple[Union[builtins.int, Union[builtins.int, tuple[Union[builtins.int, ...]]]]]
Union[builtins.int, typing.Sequence[Union[builtins.int, Union[builtins.int, typing.Sequence[Union[builtins.int, ...]]]]]]
```

**Some important notes 📝**
Since the implemented solution leads to an maximum recursive depth error when running on recursive data structure, some higher level recursive tests were not able to be added. Therefore, the below test cases only target certain cases that the implementation takes care of. In the future, once the maximum recursive depth error is fixed, more tests should be added.
For example, the following test case should succeed but it currently fails with the error `Incompatible return value type (got "Tuple[int, Tuple[Union[str, bytes], float]]", expected "Union[Tuple[int, Tuple[str, float]], Tuple[int, Tuple[bytes, float]]]")`
 ```
def exampleTest(x: Tuple[int, Tuple[Union[str, bytes], float]]) -> Union[
    Tuple[int, Tuple[str, float]],
    Tuple[int, Tuple[bytes, float]],
]:
    return x
 ```
### **Test cases 🧪**
**Success cases (testTupleUnionDistributionSuccess)**

- f1: Distribute Optional[float] in second position

- f2: Distribute Union[int,str] in first position

- f3: Distribute Union[str,None] in second position

- f4: Single-element tuple with Union[int,float]

- f5: Two positions both containing unions

**Failure cases (testTupleUnionDistributionFail)**

- g1: Mismatched first branch (str vs. expected float)

- g2: Mismatched second branch (str vs. expected float)

**Note**: Each case ends with [builtins fixtures/tuple.pyi] to import the tuple stubs required by the harness.